### PR TITLE
Ajout du champ "Est-ce que le site a été résorbé définitivement?" 

### DIFF
--- a/src/js/app/pages/towns.details/towns.details.js
+++ b/src/js/app/pages/towns.details/towns.details.js
@@ -54,6 +54,10 @@ export default {
                 { value: 0, label: 'Non' },
                 { value: -1, label: 'Inconnu' },
             ],
+            closedWithSolutionsValues: [
+                { value: true, label: 'Oui' },
+                { value: false, label: 'Non' },
+            ],
             statusValues: [
                 { value: 'closed_by_justice', label: 'Exécution d\'une décision de justice' },
                 { value: 'closed_by_admin', label: 'Exécution d\'une décision administrative' },
@@ -425,6 +429,7 @@ export default {
             // send the form
             close(this.town.id, {
                 closed_at: this.edit.closedAt,
+                closed_with_solutions: this.edit.closedWithSolutions,
                 status: this.edit.status,
                 solutions: Object.keys(this.edit.solutions)
                     .filter(key => this.edit.solutions[key].checked)

--- a/src/js/app/pages/towns.details/towns.details.js
+++ b/src/js/app/pages/towns.details/towns.details.js
@@ -126,7 +126,7 @@ export default {
                 case 'closed_by_admin':
                 case 'other':
                 case 'unknown':
-                    return 'disparu';
+                    return this.town.closedWithSolutions === 'yes' ? 'résorbé' : 'disparu';
 
                 default:
                     return 'inconnu';

--- a/src/js/app/pages/towns.details/towns.details.js
+++ b/src/js/app/pages/towns.details/towns.details.js
@@ -266,7 +266,7 @@ export default {
             this.resetEdit();
             this.mode = 'close';
         },
-        closeAlert() {
+        closePopin() {
             this.resetEdit();
             this.mode = 'view';
         },

--- a/src/js/app/pages/towns.details/towns.details.pug
+++ b/src/js/app/pages/towns.details/towns.details.pug
@@ -23,76 +23,81 @@
     <section v-else class="section section-white town-wrapper" ref="wrapper">
         <CommentDeletion v-if="commentToBeDeleted !== null" :comment="commentToBeDeleted" @close="closeCommentDeletion" @deleted="onCommentDeleted" ref="commentDeletionPopin"></CommentDeletion>
 
-        <div class="alert" v-if="mode === 'close'">
-            <div class="wrapper">
-                <h2>Disparition du site</h2>
-                <div class="form__group">
-                    <label v-bind:class="{ error: fieldErrors.closed_at }">Date de disparition du site :</label>
-                    <p class="error" v-if="fieldErrors.closed_at">
-                        <ul>
-                            <li v-for="error in fieldErrors.closed_at">{{ error }}</li>
-                        </ul>
-                    </p>
-                    <datepicker :clear-button="true" :language="dateLanguage" :monday-first="true" :disabled-dates="{ from: new Date() }" :full-month-name="true" :format="'dd MMMM yyyy'" v-model="edit.closedAt"></datepicker>
-                </div>
-
-                 <div class="form__group">
-                    <fieldset>
-                        <legend v-bind:class="{ error: fieldErrors.closed_with_solutions }">Est-ce que ce site a été résorbé définitivement ? :</legend>
-                        <p class="error" v-if="fieldErrors.closed_with_solutions">
-                            <ul>
-                                <li v-for="error in fieldErrors.closed_with_solutions">{{ error }}</li>
-                            </ul>
-                        </p>
-                        
-                        <div v-for="(value, index) in closedWithSolutionsValues">
-                            <input type="radio" name="closed_with_solutions" :id="'status' + index" :value="value.value" v-model="edit.closedWithSolutions">
-                            <label :for="'status' + index" class="label-inline">{{ value.label }}</label>
+        <div class="popin" v-if="mode === 'close'">
+            <div class="popin-wrapper" ref="wrapper">
+                <div>
+                    <p class="popin-close"><span class="link" @click="closePopin"><font-awesome-icon icon="times" size="2x"></font-awesome-icon></span></p>
+                    <section>
+                        <h2>Disparition du site</h2>
+                        <div class="form__group">
+                            <label v-bind:class="{ error: fieldErrors.closed_at }">Date de disparition du site :</label>
+                            <p class="error" v-if="fieldErrors.closed_at">
+                                <ul>
+                                    <li v-for="error in fieldErrors.closed_at">{{ error }}</li>
+                                </ul>
+                            </p>
+                            <datepicker :clear-button="true" :language="dateLanguage" :monday-first="true" :disabled-dates="{ from: new Date() }" :full-month-name="true" :format="'dd MMMM yyyy'" v-model="edit.closedAt"></datepicker>
                         </div>
-                    </fieldset>
-                </div>
 
-                <div class="form__group">
-                    <fieldset>
-                        <legend v-bind:class="{ error: fieldErrors.status }">Cause de la disparition :</legend>
-                        <p class="error" v-if="fieldErrors.status">
-                            <ul>
-                                <li v-for="error in fieldErrors.status">{{ error }}</li>
-                            </ul>
-                        </p>
-                        <div v-for="(value, index) in statusValues">
-                            <input type="radio" name="status" :id="'status' + index" :value="value.value" v-model="edit.status">
-                            <label :for="'status' + index" class="label-inline">{{ value.label }}</label>
-                        </div>
-                    </fieldset>
-                </div>
-
-                <div class="form__group">
-                    <fieldset>
-                        <legend v-bind:class="{ error: fieldErrors.solutions }">Orientations des ménages :</legend>
-                        <fieldset v-for="(value, index) in closingSolutions">
-                            <legend>
-                                <input type="checkbox" name="closingSolution" :id="'closingSolution' + index" :value="value.id" v-model="edit.solutions[value.id].checked">
-                                <label :for="'closingSolution' + index" class="label-inline">{{ value.label }}</label>
-                            </legend>
-                            <div class="solution-people" v-bind:class="{ visible: edit.solutions[value.id].checked }">
-                                <p class="error" v-if="fieldErrors.solutions && fieldErrors.solutions[value.id]">
+                         <div class="form__group">
+                            <fieldset>
+                                <legend v-bind:class="{ error: fieldErrors.closed_with_solutions }">Est-ce que ce site a été résorbé définitivement ? :</legend>
+                                <p class="error" v-if="fieldErrors.closed_with_solutions">
                                     <ul>
-                                        <li v-for="error in fieldErrors.solutions[value.id]">{{ error }}</li>
+                                        <li v-for="error in fieldErrors.closed_with_solutions">{{ error }}</li>
                                     </ul>
                                 </p>
-                                <p>Nombre de ménages concernés :<br/><input type="number" v-model="edit.solutions[value.id].householdsAffected" /></p>
-                                <p>Nombre de personnes concernées :<br/><input type="number" v-model="edit.solutions[value.id].peopleAffected" /></p>
-                            </div>
-                        </fieldset>
-                    </fieldset>
-                </div>
 
-                <div class="notification error" v-if="editError">{{ editError }}.</div>
+                                <div v-for="(value, index) in closedWithSolutionsValues">
+                                    <input type="radio" name="closed_with_solutions" :id="'status' + index" :value="value.value" v-model="edit.closedWithSolutions">
+                                    <label :for="'status' + index" class="label-inline">{{ value.label }}</label>
+                                </div>
+                            </fieldset>
+                        </div>
 
-                <div class="form__group">
-                    <button @click="submitClose" class="button">Valider</button>
-                    <button @click="closeAlert" class="button secondary">Annuler</button>
+                        <div class="form__group">
+                            <fieldset>
+                                <legend v-bind:class="{ error: fieldErrors.status }">Cause de la disparition :</legend>
+                                <p class="error" v-if="fieldErrors.status">
+                                    <ul>
+                                        <li v-for="error in fieldErrors.status">{{ error }}</li>
+                                    </ul>
+                                </p>
+                                <div v-for="(value, index) in statusValues">
+                                    <input type="radio" name="status" :id="'status' + index" :value="value.value" v-model="edit.status">
+                                    <label :for="'status' + index" class="label-inline">{{ value.label }}</label>
+                                </div>
+                            </fieldset>
+                        </div>
+
+                        <div class="form__group">
+                            <fieldset>
+                                <legend v-bind:class="{ error: fieldErrors.solutions }">Orientations des ménages :</legend>
+                                <fieldset v-for="(value, index) in closingSolutions">
+                                    <legend>
+                                        <input type="checkbox" name="closingSolution" :id="'closingSolution' + index" :value="value.id" v-model="edit.solutions[value.id].checked">
+                                        <label :for="'closingSolution' + index" class="label-inline">{{ value.label }}</label>
+                                    </legend>
+                                    <div class="solution-people" v-bind:class="{ visible: edit.solutions[value.id].checked }">
+                                        <p class="error" v-if="fieldErrors.solutions && fieldErrors.solutions[value.id]">
+                                            <ul>
+                                                <li v-for="error in fieldErrors.solutions[value.id]">{{ error }}</li>
+                                            </ul>
+                                        </p>
+                                        <p>Nombre de ménages concernés :<br/><input type="number" v-model="edit.solutions[value.id].householdsAffected" /></p>
+                                        <p>Nombre de personnes concernées :<br/><input type="number" v-model="edit.solutions[value.id].peopleAffected" /></p>
+                                    </div>
+                                </fieldset>
+                            </fieldset>
+                        </div>
+
+                        <div class="notification error" v-if="editError">{{ editError }}.</div>
+
+                        <div class="form__group">
+                            <button @click="submitClose" class="button">Valider</button>
+                            <button @click="closePopin" class="button secondary">Annuler</button>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>

--- a/src/js/app/pages/towns.details/towns.details.pug
+++ b/src/js/app/pages/towns.details/towns.details.pug
@@ -41,7 +41,10 @@
 
                          <div class="form__group">
                             <fieldset>
-                                <legend v-bind:class="{ error: fieldErrors.closed_with_solutions }">Est-ce que ce site a été résorbé définitivement ? :</legend>
+                                <legend v-bind:class="{ error: fieldErrors.closed_with_solutions }">
+                                    <strong>Est-ce que ce site a été résorbé définitivement ? :</strong>
+                                </legend>
+                                <p class="question-info">C’est-à-dire sans réinstallation illicite et avec un accompagnement de la majorité des personnes vers des solutions pérennes</p>
                                 <p class="error" v-if="fieldErrors.closed_with_solutions">
                                     <ul>
                                         <li v-for="error in fieldErrors.closed_with_solutions">{{ error }}</li>
@@ -57,7 +60,9 @@
 
                         <div class="form__group">
                             <fieldset>
-                                <legend v-bind:class="{ error: fieldErrors.status }">Cause de la disparition :</legend>
+                                <legend v-bind:class="{ error: fieldErrors.status }">
+                                    <strong>Cause de la disparition :</strong>
+                                </legend>
                                 <p class="error" v-if="fieldErrors.status">
                                     <ul>
                                         <li v-for="error in fieldErrors.status">{{ error }}</li>
@@ -72,7 +77,9 @@
 
                         <div class="form__group">
                             <fieldset>
-                                <legend v-bind:class="{ error: fieldErrors.solutions }">Orientations des ménages :</legend>
+                                <legend v-bind:class="{ error: fieldErrors.solutions }">
+                                    <strong>Orientations des ménages :</strong>
+                                </legend>
                                 <fieldset v-for="(value, index) in closingSolutions">
                                     <legend>
                                         <input type="checkbox" name="closingSolution" :id="'closingSolution' + index" :value="value.id" v-model="edit.solutions[value.id].checked">

--- a/src/js/app/pages/towns.details/towns.details.pug
+++ b/src/js/app/pages/towns.details/towns.details.pug
@@ -36,6 +36,22 @@
                     <datepicker :clear-button="true" :language="dateLanguage" :monday-first="true" :disabled-dates="{ from: new Date() }" :full-month-name="true" :format="'dd MMMM yyyy'" v-model="edit.closedAt"></datepicker>
                 </div>
 
+                 <div class="form__group">
+                    <fieldset>
+                        <legend v-bind:class="{ error: fieldErrors.closed_with_solutions }">Est-ce que ce site a été résorbé définitivement ? :</legend>
+                        <p class="error" v-if="fieldErrors.closed_with_solutions">
+                            <ul>
+                                <li v-for="error in fieldErrors.closed_with_solutions">{{ error }}</li>
+                            </ul>
+                        </p>
+                        
+                        <div v-for="(value, index) in closedWithSolutionsValues">
+                            <input type="radio" name="closed_with_solutions" :id="'status' + index" :value="value.value" v-model="edit.closedWithSolutions">
+                            <label :for="'status' + index" class="label-inline">{{ value.label }}</label>
+                        </div>
+                    </fieldset>
+                </div>
+
                 <div class="form__group">
                     <fieldset>
                         <legend v-bind:class="{ error: fieldErrors.status }">Cause de la disparition :</legend>

--- a/src/js/app/pages/towns.details/towns.details.scss
+++ b/src/js/app/pages/towns.details/towns.details.scss
@@ -242,3 +242,7 @@ fieldset {
     margin: 6px 0;
     padding: 0;
 }
+
+.question-info {
+    margin-top: 0;
+}


### PR DESCRIPTION
https://trello.com/c/5faOhDW1/551-mesurer-le-nombre-de-site-r%C3%A9sorb%C3%A9s

J'ai rajouté le champ "Est-ce que le site a été résorbé definitivement" et repris le design de la modal depuis l'annuaire. J'ai testé le coté fonctionnel avec l'API, c'est OK

Il faut peut être rajouter une tooltip d'info avec  "C’est-à-dire sans réinstallation illicite et avec un accompagnement de la majorité des personnes vers des solutions pérennes" et réstituer l'info sur la fiche du site.

![image](https://user-images.githubusercontent.com/5053593/92227666-e314e280-eea6-11ea-9b4d-c24ca9c26b11.png)


