### PR TITLE
(585) Support city districts when filtering towns.list

### DIFF
--- a/src/js/app/pages/towns.list/towns.list.js
+++ b/src/js/app/pages/towns.list/towns.list.js
@@ -233,7 +233,15 @@ export default {
                     }
 
                     const l = shantytown[this.currentLocation.data.type];
-                    return l && `${l.code}` === `${this.currentLocation.data.code}`;
+                    if (!l) {
+                        return true;
+                    }
+
+                    if (l.code === `${this.currentLocation.data.code}`) {
+                        return true;
+                    }
+
+                    return l.main === `${this.currentLocation.data.code}`;
                 });
         },
         filteredShantytowns() {


### PR DESCRIPTION
Le problème était côté front : le composant towns.list ne filtrait pas correctement les résultats du tableau parce qu'il ne prenait pas en compte les arrondissements.

Une ville sans arrondissement :
```json
{
    code: "00000",
    name: "Paris",
    main: null
}
```

Une vile avec arrondissement :
```json
{
    code: "00001",
    name: "Paris (11ème)",
    main: "00000"
}
```