### PR TITLE
(658) Désactiver Matomo hors PROD

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 VUE_APP_API_URL=http://localhost:1236
+MATOMO_ON=false

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VUE_APP_API_URL=https://api.resorption-bidonvilles.beta.gouv.fr
+MATOMO_ON=true

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -98,39 +98,39 @@ Vue.component("font-awesome-icon", FontAwesomeIcon);
 Vue.use(TrendChart);
 Vue.use(VueRouter);
 Vue.use(VueI18n);
-if (process.env.MATOMO_ON != null) {
-    if (process.env.MATOMO_ON === "true") {
-        Vue.use(VueMatomo, {
-            // Configure your matomo server and site by providing
-            host: "https://stats.data.gouv.fr",
-            siteId: 86,
 
-            // Changes the default .js and .php endpoint's filename
-            // Default: 'piwik'
-            trackerFileName: "piwik",
+if (process.env.MATOMO_ON === "true") {
+    Vue.use(VueMatomo, {
+        // Configure your matomo server and site by providing
+        host: "https://stats.data.gouv.fr",
+        siteId: 86,
 
-            // Enables automatically registering pageviews on the router
-            router,
+        // Changes the default .js and .php endpoint's filename
+        // Default: 'piwik'
+        trackerFileName: "piwik",
 
-            // Enables link tracking on regular links. Note that this won't
-            // work for routing links (ie. internal Vue router links)
-            // Default: true
-            enableLinkTracking: true,
+        // Enables automatically registering pageviews on the router
+        router,
 
-            // Require consent before sending tracking information to matomo
-            // Default: false
-            requireConsent: false,
+        // Enables link tracking on regular links. Note that this won't
+        // work for routing links (ie. internal Vue router links)
+        // Default: true
+        enableLinkTracking: true,
 
-            // Whether to track the initial page view
-            // Default: true
-            trackInitialView: true,
+        // Require consent before sending tracking information to matomo
+        // Default: false
+        requireConsent: false,
 
-            // Whether or not to log debug information
-            // Default: false
-            debug: true
-        });
-    }
+        // Whether to track the initial page view
+        // Default: true
+        trackInitialView: true,
+
+        // Whether or not to log debug information
+        // Default: false
+        debug: true
+    });
 }
+
 // Register styleguide components
 registerGlobalComponents(Vue);
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -98,36 +98,39 @@ Vue.component("font-awesome-icon", FontAwesomeIcon);
 Vue.use(TrendChart);
 Vue.use(VueRouter);
 Vue.use(VueI18n);
-Vue.use(VueMatomo, {
-    // Configure your matomo server and site by providing
-    host: "https://stats.data.gouv.fr",
-    siteId: 86,
+if (process.env.MATOMO_ON != null) {
+    if (process.env.MATOMO_ON === "true") {
+        Vue.use(VueMatomo, {
+            // Configure your matomo server and site by providing
+            host: "https://stats.data.gouv.fr",
+            siteId: 86,
 
-    // Changes the default .js and .php endpoint's filename
-    // Default: 'piwik'
-    trackerFileName: "piwik",
+            // Changes the default .js and .php endpoint's filename
+            // Default: 'piwik'
+            trackerFileName: "piwik",
 
-    // Enables automatically registering pageviews on the router
-    router,
+            // Enables automatically registering pageviews on the router
+            router,
 
-    // Enables link tracking on regular links. Note that this won't
-    // work for routing links (ie. internal Vue router links)
-    // Default: true
-    enableLinkTracking: true,
+            // Enables link tracking on regular links. Note that this won't
+            // work for routing links (ie. internal Vue router links)
+            // Default: true
+            enableLinkTracking: true,
 
-    // Require consent before sending tracking information to matomo
-    // Default: false
-    requireConsent: false,
+            // Require consent before sending tracking information to matomo
+            // Default: false
+            requireConsent: false,
 
-    // Whether to track the initial page view
-    // Default: true
-    trackInitialView: true,
+            // Whether to track the initial page view
+            // Default: true
+            trackInitialView: true,
 
-    // Whether or not to log debug information
-    // Default: false
-    debug: true
-});
-
+            // Whether or not to log debug information
+            // Default: false
+            debug: true
+        });
+    }
+}
 // Register styleguide components
 registerGlobalComponents(Vue);
 


### PR DESCRIPTION
Correction simple pour n'activer Matomo que si la variable MATOMO_ON existe bien dans le fichier de variables d'evironnement et si sa valeur est 'true'