### PR TITLE
(700) Page coupée en deux sur la fiche des sites

### DIFF
--- a/src/js/app/pages/towns.details/towns.details.js
+++ b/src/js/app/pages/towns.details/towns.details.js
@@ -283,10 +283,10 @@ export default {
 
             if (goesUp === true) {
                 if (window.pageYOffset - this.$refs.main.offsetTop <= 0) {
-                    this.$refs.wrapper.classList.remove("sticky");
+                    this.$refs.wrapper.classList.remove("rb-sticky");
                 }
             } else if (window.pageYOffset > this.offsetTop(this.$refs.header)) {
-                this.$refs.wrapper.classList.add("sticky");
+                this.$refs.wrapper.classList.add("rb-sticky");
             }
         },
         formatDate: (...args) => App.formatDate(...args),

--- a/src/js/app/pages/towns.details/towns.details.scss
+++ b/src/js/app/pages/towns.details/towns.details.scss
@@ -213,7 +213,7 @@
         }
     }
 
-    .sticky {
+    .rb-sticky {
         .town-header {
             z-index: 3000;
             position: fixed;


### PR DESCRIPTION
Conflit entre la classe .sticky du composant et la classe TailwindCSS. La clmasse du composant a été renommée .rb-sticky et le code de towns-detail.js mis à jour pour intégrer cette modification (l284-290).