### PR TITLE
(701) Tableau d'évolution de la démographie

### DIFF
--- a/cypress/integration/towns.create-edit-delete-fromFullToMin.spec.js
+++ b/cypress/integration/towns.create-edit-delete-fromFullToMin.spec.js
@@ -52,7 +52,7 @@ describe("Gestion des sites", () => {
                             // assert
                             cy.url().should("contain", "/liste-des-sites");
                             cy.visit(`/#/site/${siteId}`);
-                            cy.get(".notification.error").should(
+                            cy.get("body").should(
                                 "contain",
                                 "Le site demandé n'existe pas en base de données"
                             );

--- a/cypress/integration/towns.create-edit-delete-fromMinToFull.spec.js
+++ b/cypress/integration/towns.create-edit-delete-fromMinToFull.spec.js
@@ -52,7 +52,7 @@ describe("Gestion des sites", () => {
                             // assert
                             cy.url().should("contain", "/liste-des-sites");
                             cy.visit(`/#/site/${siteId}`);
-                            cy.get(".notification.error").should(
+                            cy.get("body").should(
                                 "contain",
                                 "Le site demandé n'existe pas en base de données"
                             );

--- a/cypress/support/commands/checkShantytownDetails.js
+++ b/cypress/support/commands/checkShantytownDetails.js
@@ -58,67 +58,63 @@ Cypress.Commands.add("checkShantytownDetails", shantytown => {
         cy.get("[data-cy-data='owner']").should("not.exist");
     }
 
-    cy.get("[data-cy-data='population_total']").should(
+    cy.get("[data-cy-data='populationTotal']").should(
         "contain",
-        shantytown.population_total !== null
-            ? shantytown.population_total
-            : "NC"
+        shantytown.population_total !== null ? shantytown.population_total : "-"
     );
 
-    cy.get("[data-cy-data='population_couples']").should(
+    cy.get("[data-cy-data='populationCouples']").should(
         "contain",
         shantytown.population_couples !== null
             ? shantytown.population_couples
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='population_minors']").should(
+    cy.get("[data-cy-data='populationMinors']").should(
         "contain",
         shantytown.population_minors !== null
             ? shantytown.population_minors
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='population_minors_0_3']").should(
+    cy.get("[data-cy-data='populationMinors0To3']").should(
         "contain",
         shantytown.population_minors_0_3 !== null
             ? shantytown.population_minors_0_3
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='population_minors_3_6']").should(
+    cy.get("[data-cy-data='populationMinors3To6']").should(
         "contain",
         shantytown.population_minors_3_6 !== null
             ? shantytown.population_minors_3_6
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='population_minors_6_12']").should(
+    cy.get("[data-cy-data='populationMinors6To12']").should(
         "contain",
         shantytown.population_minors_6_12 !== null
             ? shantytown.population_minors_6_12
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='population_minors_12_16']").should(
+    cy.get("[data-cy-data='populationMinors12To16']").should(
         "contain",
         shantytown.population_minors_12_16 !== null
             ? shantytown.population_minors_12_16
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='population_minors_16_18']").should(
+    cy.get("[data-cy-data='populationMinors16To18']").should(
         "contain",
         shantytown.population_minors_16_18 !== null
             ? shantytown.population_minors_16_18
-            : "NC"
+            : "-"
     );
 
-    cy.get("[data-cy-data='minors_in_school']").should(
+    cy.get("[data-cy-data='minorsInSchool']").should(
         "contain",
-        shantytown.minors_in_school !== null
-            ? shantytown.minors_in_school
-            : "NC"
+        shantytown.minors_in_school !== null ? shantytown.minors_in_school : "-"
     );
 
     if (shantytown.social_origins.length > 0) {

--- a/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/src/js/app/pages/TownDetails/TownDetails.vue
@@ -4,6 +4,13 @@
             <Spinner />
         </div>
     </PrivateLayout>
+
+    <PrivateLayout v-else-if="error !== null">
+        <div class="text-center text-error text-primary text-display-lg mt-16">
+            {{ error }}
+        </div>
+    </PrivateLayout>
+
     <PrivateLayout v-else>
         <PrivateContainer v-if="town" class="py-10">
             <TownDetailsHeader
@@ -208,10 +215,11 @@ export default {
                 .then(town => {
                     this.loading = false;
                     this.town = enrichShantytown(town, this.fieldTypes);
-                    this.resetEdit();
                 })
                 .catch(errors => {
-                    this.error = errors.user_message;
+                    this.error =
+                        (errors && errors.user_message) ||
+                        "Une erreur inconnue est survenue";
                     this.loading = false;
                 });
         }

--- a/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -55,6 +55,9 @@
                                     'bg-gray-100': colIndex === 0
                                 }"
                                 v-bind:key="colIndex"
+                                :data-cy-data="
+                                    colIndex === 0 ? section.data : undefined
+                                "
                             >
                                 {{ col[section.data] }}
                             </td>
@@ -212,7 +215,7 @@ export default {
                     "-"
                 ),
                 populationMinors16To18: this.intToStr(
-                    this.town.populationMinors16To1,
+                    this.town.populationMinors16To18,
                     "-"
                 ),
                 minorsInSchool: this.intToStr(this.town.minorsInSchool, "-")

--- a/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -3,103 +3,64 @@
         <template v-slot:title>Habitants</template>
         <template v-slot:body>
             <TownDetailsPanelSection>
-                <div class="flex">
-                    <div class="mr-4">
-                        <Icon icon="male" class="text-xl"></Icon>
-                    </div>
-                    <div>
-                        <div class="flex items-center mb-4">
-                            <div class="text-display-md">
-                                Personnes :
-                            </div>
-                            <div
-                                class="text-display-sm ml-2 mr-10 font-normal"
-                                data-cy-data="population_total"
-                            >
-                                {{
-                                    Number.isInteger(town.populationTotal)
-                                        ? town.populationTotal
-                                        : "NC"
-                                }}
-                            </div>
-                            <div class="text-display-md">
-                                Ménages :
-                            </div>
-                            <div
-                                class="text-display-sm ml-2 mr-10 font-normal"
-                                data-cy-data="population_couples"
-                            >
-                                {{
-                                    Number.isInteger(town.populationCouples)
-                                        ? town.populationCouples
-                                        : "NC"
-                                }}
-                            </div>
-                            <div class="text-display-md">
-                                Mineurs :
-                            </div>
-                            <div
-                                class="text-display-sm ml-2 mr-10 font-normal"
-                                data-cy-data="population_minors"
-                            >
-                                {{
-                                    Number.isInteger(town.populationMinors)
-                                        ? town.populationMinors
-                                        : "NC"
-                                }}
-                            </div>
-                        </div>
-                        <div class="flex items-center mb-4">
-                            <div
-                                class="mr-10"
-                                data-cy-data="population_minors_0_3"
-                            >
-                                <span class="text-display-xs">0 - 3 ans :</span
-                                ><br />{{ populationMinors0To3 }}
-                            </div>
-                            <div
-                                class="mr-10"
-                                data-cy-data="population_minors_3_6"
-                            >
-                                <span class="text-display-xs">3 - 6 ans :</span
-                                ><br />{{ populationMinors3To6 }}
-                            </div>
-                            <div
-                                class="mr-10"
-                                data-cy-data="population_minors_6_12"
-                            >
-                                <span class="text-display-xs">6 - 12 ans :</span
-                                ><br />{{ populationMinors6To12 }}
-                            </div>
-                            <div
-                                class="mr-10"
-                                data-cy-data="population_minors_12_16"
-                            >
-                                <span class="text-display-xs"
-                                    >12 - 16 ans :</span
-                                ><br />{{ populationMinors12To16 }}
-                            </div>
-                            <div
-                                class="mr-10"
-                                data-cy-data="population_minors_16_18"
-                            >
-                                <span class="text-display-xs"
-                                    >16 - 18 ans :</span
-                                ><br />{{ populationMinors16To18 }}
-                            </div>
-                        </div>
-                        <div class="flex">
-                            <div class="mr-10" data-cy-data="minors_in_school">
-                                <span class="text-display-xs"
-                                    >Inscrits en établissement scolaire :</span
-                                ><br />{{ minorsInSchool }}
-                            </div>
-                        </div>
-                    </div>
+                <div class="italic mb-4">
+                    Le nombre de personnes sur un site est mouvant, les données
+                    fournies par les acteurs, même des estimations, participent
+                    à l'amélioration de la connaissance.
                 </div>
-                <div class="text-right italic">
-                    *NC = non communiqué
-                </div>
+
+                <table class="table-fixed text-center mb-6">
+                    <thead>
+                        <tr>
+                            <td></td>
+                            <td class="border-b"></td>
+                            <td
+                                v-for="(col, colIndex) in populationHistory"
+                                class="w-24 py-2 border-b"
+                                v-bind:class="{
+                                    'font-bold': colIndex === 0,
+                                    'bg-gray-200': colIndex === 0
+                                }"
+                                v-bind:key="colIndex"
+                            >
+                                {{ col.date }}<br />{{ col.year }}
+                            </td>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr
+                            v-for="(section, index) in sections"
+                            :class="section.css"
+                            v-bind:key="index"
+                        >
+                            <td
+                                v-if="index === 0"
+                                class="align-top pr-2 text-xl"
+                                :rowspan="sections.length"
+                            >
+                                <Icon icon="male" class="mr-1"></Icon>
+                                <Icon icon="male"></Icon>
+                            </td>
+                            <td class="text-left pr-4 border-b">
+                                {{ section.title }}
+                            </td>
+                            <td
+                                v-for="(col, colIndex) in populationHistory"
+                                class="py-1 border-b"
+                                v-bind:class="{
+                                    'border-r':
+                                        colIndex > 0 ||
+                                        populationHistory.length <= 1,
+                                    'bg-gray-100': colIndex === 0
+                                }"
+                                v-bind:key="colIndex"
+                            >
+                                {{ col[section.data] }}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
 
                 <div>
                     <div class="font-bold">Origine</div>
@@ -159,6 +120,32 @@ export default {
             type: Object
         }
     },
+    data() {
+        return {
+            sections: [
+                {
+                    title: "Personnes",
+                    css: "font-bold",
+                    data: "populationTotal"
+                },
+                {
+                    title: "Ménages",
+                    css: "font-bold",
+                    data: "populationCouples"
+                },
+                { title: "Mineurs", data: "populationMinors" },
+                { title: "0 - 3 ans", data: "populationMinors0To3" },
+                { title: "3 - 6 ans", data: "populationMinors3To6" },
+                { title: "6 - 12 ans", data: "populationMinors6To12" },
+                { title: "12 - 16 ans", data: "populationMinors12To16" },
+                { title: "16 - 18 ans", data: "populationMinors16To18" },
+                {
+                    title: "Inscrits en établissement scolaire",
+                    data: "minorsInSchool"
+                }
+            ]
+        };
+    },
     components: { TownDetailsPanel, TownDetailsPanelSection },
     methods: {
         /**
@@ -186,15 +173,79 @@ export default {
 
             return origin;
         },
-        intToStr(int) {
+        intToStr(int, nullValue = "NC") {
             if (int === undefined || int === null) {
-                return "NC";
+                return nullValue;
             }
 
             return int;
         }
     },
     computed: {
+        populationHistory() {
+            const present = {
+                date: this.formatDate(this.town.updatedAt, "d B"),
+                year: this.formatDate(this.town.updatedAt, "y"),
+                populationTotal: this.intToStr(this.town.populationTotal, "-"),
+                populationCouples: this.intToStr(
+                    this.town.populationCouples,
+                    "-"
+                ),
+                populationMinors: this.intToStr(
+                    this.town.populationMinors,
+                    "-"
+                ),
+                populationMinors0To3: this.intToStr(
+                    this.town.populationMinors0To3,
+                    "-"
+                ),
+                populationMinors3To6: this.intToStr(
+                    this.town.populationMinors3To6,
+                    "-"
+                ),
+                populationMinors6To12: this.intToStr(
+                    this.town.populationMinors6To12,
+                    "-"
+                ),
+                populationMinors12To16: this.intToStr(
+                    this.town.populationMinors12To16,
+                    "-"
+                ),
+                populationMinors16To18: this.intToStr(
+                    this.town.populationMinors16To1,
+                    "-"
+                ),
+                minorsInSchool: this.intToStr(this.town.minorsInSchool, "-")
+            };
+
+            let ref = { ...present };
+            const past = this.town.changelog.reduce((acc, log, index) => {
+                const diff = log.diff.filter(({ fieldKey }) =>
+                    fieldKey.startsWith("population")
+                );
+                if (diff.length === 0) {
+                    return acc;
+                }
+
+                let date;
+                if (index < this.town.changelog.length - 1) {
+                    date = this.town.changelog[index + 1].date;
+                } else {
+                    date = this.town.createdAt;
+                }
+
+                ref.date = this.formatDate(date, "d B");
+                ref.year = this.formatDate(date, "y");
+                diff.forEach(({ fieldKey, oldValue }) => {
+                    ref[fieldKey] =
+                        oldValue === "non renseigné" ? "-" : oldValue;
+                });
+
+                return [...acc, { ...ref }];
+            }, []);
+
+            return [present, ...past];
+        },
         socialDiagnostic() {
             if (this.town.censusStatus === "done") {
                 return `Réalisé le ${this.formatDate(

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -24,18 +24,18 @@ import { router } from "#app/router";
 import store from "#app/store";
 
 const MONTHS = [
-    "Janvier",
-    "Février",
-    "Mars",
-    "Avril",
-    "Mai",
-    "Juin",
-    "Juillet",
-    "Août",
-    "Septembre",
-    "Octobre",
-    "Novembre",
-    "Décembre"
+    { long: "Janvier", short: "jan." },
+    { long: "Février", short: "fév." },
+    { long: "Mars", short: "mars" },
+    { long: "Avril", short: "avr." },
+    { long: "Mai", short: "mai" },
+    { long: "Juin", short: "juin" },
+    { long: "Juillet", short: "juil." },
+    { long: "Août", short: "août" },
+    { long: "Septembre", short: "sep." },
+    { long: "Octobre", short: "oct." },
+    { long: "Novembre", short: "nov." },
+    { long: "Décembre", short: "déc." }
 ];
 
 window.App = Object.freeze({
@@ -90,7 +90,8 @@ window.App = Object.freeze({
             .replace("y", date.getFullYear())
             .replace("h", `0${date.getHours()}`.slice(-2))
             .replace("i", `0${date.getMinutes()}`.slice(-2))
-            .replace("M", MONTHS[date.getMonth()]);
+            .replace("M", MONTHS[date.getMonth()].long)
+            .replace("B", MONTHS[date.getMonth()].short);
     }
 });
 


### PR DESCRIPTION
#### 📄 Description rapide
Remplacement des champs de population précédents par un tableau qui donne la population à l'instant T + les états précédents (s'il y en a).
Les états précédents sont calculés à partir du changelog.

#### 🗄 Tickets
- [701](https://trello.com/c/tEdCs5gZ/701-tableau-de-l%C3%A9volution-de-la-d%C3%A9mographie)

#### 🔗 PR associées
https://github.com/MTES-MCT/action-bidonvilles-api/pull/41