### PR TITLE
(618) Coordonnées GPS d'un site

### DIFF
--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -84,7 +84,7 @@ export default {
                 },
                 {
                     id: "address_details",
-                    label: "Informations d'accès au site",
+                    label: "Informations d'accès au site et coordonnées GPS",
                     closedTowns: false
                 },
                 {

--- a/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelCharacteristics.vue
@@ -70,6 +70,25 @@
                         </div>
                     </TownDetailsPanelSection>
                     <TownDetailsPanelSection>
+                        <div class="font-bold">
+                            Coordonnées GPS
+                        </div>
+                        <div data-cy-data="address_details">
+                            Lat {{ town.latitude }}, Long
+                            {{ town.longitude }}
+                        </div>
+                        <div>
+                            <Button
+                                variant="primaryText"
+                                icon="copy"
+                                iconPosition="left"
+                                @click="copyCoordinates"
+                                href="#"
+                                >Copier</Button
+                            >
+                        </div>
+                    </TownDetailsPanelSection>
+                    <TownDetailsPanelSection>
                         <div class="grid grid-cols-2">
                             <div class="font-bold">
                                 Propriétaire
@@ -111,6 +130,7 @@ import TownDetailsPanel from "./ui/TownDetailsPanel.vue";
 import Map from "#app/components/map/map.vue";
 import TownDetailsPanelSection from "./ui/TownDetailsPanelSection.vue";
 import formatDateSince from "../TownsList/formatDateSince";
+import { notify } from "#helpers/notificationHelper";
 
 export default {
     props: {
@@ -126,7 +146,22 @@ export default {
         formatDate(...args) {
             return window.App.formatDate.apply(window, args);
         },
-        formatDateSince
+        formatDateSince,
+        copyCoordinates() {
+            const input = document.createElement("input");
+            input.value = `${this.town.latitude},${this.town.longitude}`;
+            document.body.appendChild(input);
+            input.select();
+            document.execCommand("copy");
+            document.body.removeChild(input);
+
+            notify({
+                group: "notifications",
+                type: "success",
+                title: "Succès",
+                text: "Les coordonnées ont été copiées dans le presse-papier"
+            });
+        }
     },
     computed: {
         buildAt() {

--- a/src/js/icons/index.js
+++ b/src/js/icons/index.js
@@ -71,7 +71,8 @@ import {
     faScroll,
     faCalendar,
     faPrint,
-    faFile
+    faFile,
+    faCopy
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faFlag);
@@ -145,3 +146,4 @@ library.add(faScroll);
 library.add(faCalendar);
 library.add(faPrint);
 library.add(faFile);
+library.add(faCopy);


### PR DESCRIPTION
#### 📄 Description rapide
Ajout d'une section qui décrit les coordonnées GPS d'un site + un bouton pour les copier dans le presse-papier.

#### 🗄 Tickets
- [618](https://trello.com/c/tEdCs5gZ/701-tableau-de-l%C3%A9volution-de-la-d%C3%A9mographie)

#### 🔗 PR associées
- https://github.com/MTES-MCT/action-bidonvilles-api/pull/42