### PR TITLE
(480) Ajout de l'année dans le tableau des indicateurs

### DIFF
--- a/src/js/app/pages/plans.details/plans.details.pug
+++ b/src/js/app/pages/plans.details/plans.details.pug
@@ -214,7 +214,7 @@
                             <thead>
                                 <tr>
                                     <th></th>
-                                    <th v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 
@@ -289,7 +289,7 @@
                             <thead>
                                 <tr>
                                     <th class="table-col">Nombre de personnes ayant</th>
-                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 
@@ -321,7 +321,7 @@
                             <thead>
                                 <tr>
                                     <th class="table-col"></th>
-                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 
@@ -371,7 +371,7 @@
                             <thead>
                                 <tr>
                                     <th class="table-col"></th>
-                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 
@@ -415,7 +415,7 @@
                             <thead>
                                 <tr>
                                     <th class="table-col"></th>
-                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 
@@ -489,7 +489,7 @@
                             <thead>
                                 <tr>
                                     <th class="table-col"></th>
-                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 
@@ -522,7 +522,7 @@
                             <thead>
                                 <tr>
                                     <th class="table-col"></th>
-                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd M') }}</th>
+                                    <th class="table-col" v-for="state in plan.states">{{ formatDate(new Date(state.date).getTime() / 1000, 'd B y') }}</th>
                                 </tr>
                             </thead>
 


### PR DESCRIPTION
⚠️⚠️⚠️ À MERGER APRÈS LE TICKET 701 : #54 ⚠️⚠️⚠️

Exemple :
![Capture d’écran 2021-02-15 à 14 22 39](https://user-images.githubusercontent.com/1801091/107951854-4435fb80-6f99-11eb-84c0-d5a66471d894.png)
