### PR TITLE
(687) Ajout d'un indicateur "Mineurs bénéficiant d'une médiation"

### DIFF
--- a/src/js/app/pages/plans.details/plans.details.pug
+++ b/src/js/app/pages/plans.details/plans.details.pug
@@ -381,6 +381,10 @@
                                     <td v-for="state in plan.states">{{ state.education.scolarisables === null ? 'NC' : state.education.scolarisables }}</td>
                                 </tr>
                                 <tr>
+                                    <td>Mineurs bénéficiant d'une action de médiation (3 - 18 ans)</td>
+                                    <td v-for="state in plan.states">{{ state.education.en_mediation === null ? 'NC' : state.education.en_mediation }}</td>
+                                </tr>
+                                <tr>
                                     <td>Inscrits en maternelle</td>
                                     <td v-for="state in plan.states">{{ state.education.maternelles === null ? 'NC' : state.education.maternelles }}</td>
                                 </tr>

--- a/src/js/app/pages/plans.marks/plans.marks.js
+++ b/src/js/app/pages/plans.marks/plans.marks.js
@@ -192,6 +192,15 @@ export default {
                                 return !!date;
                             }
                         },
+                        en_mediation: {
+                            type: "number",
+                            label:
+                                "Combien bénéficient d’une action de médiation (3 – 18 ans) ?",
+                            mandatory: false,
+                            condition({ date }) {
+                                return !!date;
+                            }
+                        },
                         maternelles: {
                             type: "number",
                             label: "Enfants inscrits en maternelle",


### PR DESCRIPTION
À tester/merger avec la PR côté API : https://github.com/MTES-MCT/action-bidonvilles-api/pull/44

Ajout d'un champ à deux endroits :
- dans le tableau des indicateurs, sur la fiche d'un dispositif
- dans le formulaire de saisie des indicateurs, dans la section "Éducation"

![Capture d’écran 2021-02-15 à 15 36 22](https://user-images.githubusercontent.com/1801091/107959324-90863900-6fa3-11eb-8763-3133d4548aef.png)
![Capture d’écran 2021-02-15 à 15 36 41](https://user-images.githubusercontent.com/1801091/107959357-9aa83780-6fa3-11eb-9b40-84581bf7ed03.png)
