### PR TITLE
(812) Correctifs divers autour du filtre géographique des sites

### DIFF
--- a/src/js/app/components/TownForm/inputs/InputAddress.vue
+++ b/src/js/app/components/TownForm/inputs/InputAddress.vue
@@ -8,7 +8,7 @@
         validationName="Adresse"
         @submit="submit"
         data-cy-field="address"
-        :defaultValue="value.label || ''"
+        :defaultValue="value"
     ></AutocompleteV2>
 </template>
 

--- a/src/js/app/components/ui/Autocomplete.vue
+++ b/src/js/app/components/ui/Autocomplete.vue
@@ -10,7 +10,7 @@
             <InputLabel :label="label" :info="info" />
             <AutocompleteVue
                 :search="search"
-                :default-value="defaultValue"
+                :default-value="searchInput"
                 :placeholder="placeholder"
                 :aria-label="placeholder"
                 :getResultValue="getResultValue"
@@ -164,9 +164,8 @@ export default {
             required: true
         },
         defaultValue: {
-            type: String,
-            required: false,
-            default: ""
+            type: Object,
+            required: false
         },
         placeholder: {
             type: String
@@ -205,7 +204,7 @@ export default {
         return {
             show: true,
             focused: false,
-            value: this.defaultValue || "",
+            value: this.defaultValue || {},
             searchInput: this.defaultValue
                 ? this.getResultValue(this.defaultValue)
                 : "",

--- a/src/js/app/pages/TownsList/TownsListSearchBar.vue
+++ b/src/js/app/pages/TownsList/TownsListSearchBar.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="mx-auto searchbox -mb-6">
         <AutocompleteV2
-            id="test"
             :defaultValue="this.$props.value"
             :search="search"
             v-model="result"
@@ -81,16 +80,13 @@ export default {
     },
     data() {
         return {
-            input: "test",
+            input: "",
             result: "",
             results: [],
             loading: false
         };
     },
     methods: {
-        onSubmit() {
-            alert(this.result);
-        },
         resultValue(input) {
             return input.label;
         },

--- a/src/js/app/store/index.js
+++ b/src/js/app/store/index.js
@@ -68,6 +68,11 @@ export default new Vuex.Store({
                                 user.organization.location.type
                             ].name,
                         category: user.organization.location.type,
+                        locationType: user.organization.location.type,
+                        code:
+                            user.organization.location[
+                                user.organization.location.type
+                            ].code,
                         data: {
                             code:
                                 user.organization.location[

--- a/src/js/helpers/addressHelper.js
+++ b/src/js/helpers/addressHelper.js
@@ -126,7 +126,11 @@ export function autocompleteLocation(strSearch) {
             code: result.code,
             type: result.label,
             locationType: result.type,
-            departement: result.departement
+            departement: result.departement,
+            data: {
+                code: result.code,
+                type: result.label
+            }
         }))
     );
     p2.abort = p1.abort;


### PR DESCRIPTION
- le filtre géographique par défaut n'était pas appliqué : le champ était rempli avec la bonne localisation, mais les sites affichés n'étaient pas effectivement filtrés (données de localisation manquantes à l'initialisation dans le store)
- l'export était cassé dès que l'on modifiait le filtre géographique : des données de localisation étaient manquantes (elles étaient définies à l'initialisation dans le store, mais pas depuis la barre d'autocomplete)
- correctif de typing des composants d'autocomplete pour virer des warnings Vue