### PR TITLE
Correctifs mineurs sur la fiche site / liste  des sites

### DIFF
--- a/src/js/app/components/TownForm/TownForm.vue
+++ b/src/js/app/components/TownForm/TownForm.vue
@@ -10,6 +10,7 @@
                         >
                         <Button
                             class="ml-5"
+                            variant="tertiary"
                             :loading="loading"
                             data-cy-button="submit"
                             >Valider</Button
@@ -70,7 +71,9 @@
             <div class="pt-12 pb-16">
                 <PrivateContainer class="flex justify-end items-baseline">
                     <Button variant="primaryText" @click="back">Annuler</Button>
-                    <Button class="ml-5" :loading="loading">Valider</Button>
+                    <Button class="ml-5" variant="tertiary" :loading="loading"
+                        >Valider</Button
+                    >
                 </PrivateContainer>
             </div>
         </form>

--- a/src/js/app/components/TownForm/TownFormPanelInfo.vue
+++ b/src/js/app/components/TownForm/TownFormPanelInfo.vue
@@ -10,13 +10,12 @@
             ><Icon :icon="togglerIcon" class="cursor-pointer"></Icon
         ></span>
         <transition name="toggle" mode="out-in">
-            <div class="bg-yellow-200 text-sm p-6 mt-2 flex" v-if="visible">
-                Un site est un bidonville, squat ou immeuble bâti occupé de
-                manière informelle à des fins d'habitation par plusieurs
-                familles ou personnes. Il se caractérise généralement par
-                l'absence de services de base : eau, électricité, gestion des
-                déchets. La plateforme permet de recenser tous les sites,
-                quelque soit l'origine des personnes et leur nombre.
+            <div class="bg-yellow-200 p-6 mt-2 flex" v-if="visible">
+                Un site est un bidonville ou squat occupé de manière informelle
+                à des fins d'habitation par plusieurs familles ou personnes, les
+                services de base (eau, électricité, gestion des déchets…) y sont
+                généralement absents. Tous les sites, quelque soit l'origine et
+                le nombre des personnes, peuvent être renseignés.
             </div>
         </transition>
     </div>

--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -16,7 +16,7 @@
                     <div class="font-bold mt-2">{{ location.label }}</div>
                 </div>
                 <div class="ml-16">
-                    <Button variant="primaryOutline" @click="close">
+                    <Button variant="primaryText" @click="close">
                         Annuler</Button
                     >
                     <Button @click="download" class="ml-6">Exporter</Button>

--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -19,7 +19,13 @@
                     <Button variant="primaryText" @click="close">
                         Annuler</Button
                     >
-                    <Button @click="download" class="ml-6">Exporter</Button>
+                    <Button
+                        @click="download"
+                        class="ml-6"
+                        icon="file-excel"
+                        iconPosition="left"
+                        >Exporter</Button
+                    >
                 </div>
             </div>
         </template>

--- a/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
@@ -21,7 +21,7 @@
                 <Button variant="primaryText" @click="cancelComment"
                     >Annuler</Button
                 >
-                <Button variant="primary" @click="addComment">Valider</Button>
+                <Button variant="tertiary" @click="addComment">Valider</Button>
             </div>
         </div>
     </div>

--- a/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -159,17 +159,17 @@ export default {
         },
         socialOrigin(origin) {
             if (origin.id === 1) {
-                return { id: 1, label: origin.label, img: flagFR };
+                return { id: 1, label: "Français", img: flagFR };
             }
 
             if (origin.id === 2) {
-                return { id: 2, label: origin.label, img: flagEU };
+                return { id: 2, label: "Union européenne", img: flagEU };
             }
 
             if (origin.id === 3) {
                 return {
                     id: 3,
-                    label: origin.label,
+                    label: "Hors Union européenne",
                     img: flagExtraCommunautaires
                 };
             }

--- a/src/js/app/pages/TownsList/TownCard.vue
+++ b/src/js/app/pages/TownsList/TownCard.vue
@@ -158,13 +158,13 @@
                         {{ lastUpdate }}
                     </Tag>
                     <div class="print:hidden">
-                        <transition name="fade">
+                        <transition name="fade" v-if="isOpen">
                             <router-link
                                 v-if="isHover"
-                                :to="`site/${shantytown.id}`"
+                                :to="`site/${shantytown.id}/mise-a-jour`"
                             >
                                 <Button
-                                    variant="secondaryText"
+                                    variant="primaryText"
                                     icon="pen"
                                     iconPosition="left"
                                     class="text-display-sm hover:underline -mb-1"
@@ -243,6 +243,9 @@ export default {
         }
     },
     computed: {
+        isOpen() {
+            return this.shantytown.status === "open";
+        },
         lastUpdate() {
             const { days, months, weeks } = getSince(this.shantytown.updatedAt);
 


### PR DESCRIPTION
- [821 - Sur la liste des sites, le lien "Mettre à jour" ne fonctionne pas, il amène sur la page d'un site et non pas la page de modification + le tester en bleu pour être cohérent avec la page de modification où il est bleu (je dis tester parce qu'il faut vérifier qu'il reste bien visible en bleu, me contacter lors de la modif')](https://trello.com/c/QvvGADX1/821-sur-la-liste-des-sites-le-lien-mettre-%C3%A0-jour-ne-fonctionne-pas-il-am%C3%A8ne-sur-la-page-dun-site-et-non-pas-la-page-de-modification)
- [822 - Retirer le bouton "Mettre à jour" de la liste des sites fermés, on ne peut pas modifier un site fermé](https://trello.com/c/njMYGyuy/822-retirer-le-bouton-mettre-%C3%A0-jour-de-la-liste-des-sites-ferm%C3%A9s-on-ne-peut-pas-modifier-un-site-ferm%C3%A9)
- [823 - Bouton "Valider" toujours vert](https://trello.com/c/0MFHHhBA/823-bouton-valider-toujours-vert)
- [824 - Bouton "Annuler" sans box sur la modale d'export](https://trello.com/c/M3vO64KB/824-bouton-annuler-sans-box-sur-la-modale-dexport)
- [825 - Pop-up d'export, avoir le picto Excel sur le bouton Exporter pour être cohérent avec le bouton sur la liste des sites](https://trello.com/c/cI3SEwfW/825-pop-up-dexport-avoir-le-picto-excel-sur-le-bouton-exporter-pour-%C3%AAtre-coh%C3%A9rent-avec-le-bouton-sur-la-liste-des-sites)
- [830 - Sur la fiche d'un site, remplacer "Ressortissants européens" par "Union européenne", "Ressortissants extracommunautaires" par "Hors Union européenne", "Ressortissants français" par "Français" pour être cohérent avec le tableau](https://trello.com/c/E824zSOb/830-sur-la-fiche-dun-site-remplacer-ressortissants-europ%C3%A9ens-par-union-europ%C3%A9enne-ressortissants-extracommunautaires-par-hors-union)