### PR TITLE
(836 & 746) Remplacer "Exporter les sites existants" par "Exporter les sites fermés" + Supprimer priorité

### DIFF
--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -11,7 +11,11 @@
             >
                 <div class="text-primary">
                     <div class="text-display-md text-primary">
-                        Exporter les sites existants
+                        {{
+                            closedTowns
+                                ? "Exporter les sites fermés"
+                                : "Exporter les sites existants"
+                        }}
                     </div>
                     <div class="font-bold mt-2">{{ location.label }}</div>
                 </div>
@@ -82,12 +86,6 @@ export default {
     data() {
         return {
             existingOptions: [
-                {
-                    id: "priority",
-                    label: "Priorité",
-                    description: "(1, 2, 3)",
-                    closedTowns: false
-                },
                 {
                     id: "address_details",
                     label: "Informations d'accès au site et coordonnées GPS",

--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -39,19 +39,13 @@
                     Les données exportées par défaut
                 </div>
                 <ul>
-                    <li>- Localisation : département, commune, adresse</li>
+                    <li>- Localisation</li>
                     <li>
-                        - Site : type de site (terrain / bâti), date
-                        d’installation, date de signalement
+                        - Caractéristiques du site
                     </li>
                     <li>
-                        - Habitants : nombre de personnes, mineurs, ménages et
-                        origines
+                        - Habitants
                     </li>
-                    <li v-if="closedTowns">
-                        - Orientations des ménages après la fermeture
-                    </li>
-                    <li>- Date de la dernière mise à jour</li>
                 </ul>
             </div>
             <div class="mt-4">
@@ -93,24 +87,19 @@ export default {
                 },
                 {
                     id: "owner",
-                    label: "Propriétaire",
-                    description: ": type et identité"
+                    label: "Propriétaire"
                 },
                 {
                     id: "life_conditions",
-                    label: "Conditions de vie",
-                    description:
-                        ": accès à l'électricité, l'eau, toilettes, évacuation des déchets"
+                    label: "Conditions de vie"
                 },
                 {
                     id: "demographics",
-                    label: "Diagnostic",
-                    description: ": statut, date, et service en charge"
+                    label: "Diagnostic"
                 },
                 {
                     id: "justice",
                     label: "Procédures judiciaires",
-                    description: ": statut et date des étapes",
                     permission: {
                         entity: "shantytown",
                         feature: "export",


### PR DESCRIPTION
- https://trello.com/c/0MXtB30W/836-remplacer-exporter-les-sites-existants-par-exporter-les-sites-ferm%C3%A9s-de-la-pop-dexport-des-sites-ferm%C3%A9s
- https://trello.com/c/GyeVAI3u/746-supprimer-la-priorit%C3%A9-de-la-pop-up-et-de-lexport-liste-de-sites-ajustement-des-wording-de-la-pop-up-dexport