### PR TITLE
(826) Filtre "Origines", retirer le "e" à inconnu pour être cohérent avec le formulaire et les autres filtres

### DIFF
--- a/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -72,7 +72,7 @@
                             v-if="!town.socialOrigins.length"
                             class="text-G600"
                         >
-                            inconnue
+                            inconnu
                         </div>
                         <div
                             class="flex items-center"

--- a/src/js/app/pages/TownsList/TownCard.vue
+++ b/src/js/app/pages/TownsList/TownCard.vue
@@ -53,7 +53,7 @@
                             v-if="shantytown.populationTotal === null"
                             class="font-bold"
                         >
-                            Population inconnue
+                            Population : inconnu
                         </div>
                         <div v-else class="text-lg font-bold flex items-center">
                             <div class="mr-2">
@@ -77,7 +77,7 @@
                                 v-if="!shantytown.socialOrigins.length"
                                 class="text-G600"
                             >
-                                Origine : inconnue
+                                Origine : inconnu
                             </div>
                             <div
                                 class="flex"

--- a/src/js/app/pages/TownsList/TownsList.vue
+++ b/src/js/app/pages/TownsList/TownsList.vue
@@ -144,7 +144,7 @@
                                 },
                                 {
                                     value: null,
-                                    label: 'Inconnue'
+                                    label: 'Inconnu'
                                 }
                             ]"
                         />


### PR DESCRIPTION
https://trello.com/c/r7pPQoAH/826-filtre-origines-retirer-le-e-%C3%A0-inconnu-pour-%C3%AAtre-coh%C3%A9rent-avec-le-formulaire-et-les-autres-filtres