### PR TITLE
(833/852) Correctifs sur l'historique des habitants

### DIFF
--- a/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -186,9 +186,8 @@ export default {
     },
     computed: {
         populationHistory() {
-            const present = {
-                date: this.formatDate(this.town.updatedAt, "d B"),
-                year: this.formatDate(this.town.updatedAt, "y"),
+            // valeurs présentes
+            let ref = {
                 populationTotal: this.intToStr(this.town.populationTotal, "-"),
                 populationCouples: this.intToStr(
                     this.town.populationCouples,
@@ -221,35 +220,65 @@ export default {
                 minorsInSchool: this.intToStr(this.town.minorsInSchool, "-")
             };
 
-            let ref = { ...present };
-            const past = this.town.changelog.reduce((acc, log, index) => {
-                const diff = log.diff.filter(
-                    ({ fieldKey }) =>
-                        fieldKey.startsWith("population") ||
-                        fieldKey === "minorsInSchool"
-                );
-                if (diff.length === 0) {
-                    return acc;
-                }
-
-                let date;
-                if (index < this.town.changelog.length - 1) {
-                    date = this.town.changelog[index + 1].date;
-                } else {
-                    date = this.town.createdAt;
-                }
-
-                ref.date = this.formatDate(date, "d B");
-                ref.year = this.formatDate(date, "y");
-                diff.forEach(({ fieldKey, oldValue }) => {
-                    ref[fieldKey] =
-                        oldValue === "non renseigné" ? "-" : oldValue;
+            // on traite le changelog pour n'y conserver que les étapes qui contiennent au moins un changement sur les champs de population
+            const entries = this.town.changelog
+                .map(entry => {
+                    return {
+                        ...entry,
+                        diff: entry.diff.filter(
+                            ({ fieldKey }) =>
+                                fieldKey.startsWith("population") ||
+                                fieldKey === "minorsInSchool"
+                        )
+                    };
+                })
+                .filter(({ diff }) => {
+                    return diff.length > 0;
                 });
 
-                return [...acc, { ...ref }];
-            }, []);
+            // s'il n'y a jamais eu de changement sur les champs de population, on a une seule entrée dans l'historique, à savoir les valeurs présentes, à la date de déclaration du site sur la plateforme
+            if (entries.length === 0) {
+                return [
+                    {
+                        ...ref,
+                        date: this.formatDate(this.town.createdAt, "d B"),
+                        year: this.formatDate(this.town.createdAt, "y")
+                    }
+                ];
+            }
 
-            return [present, ...past];
+            // s'il y a eu au moins une modification
+            return [
+                // la première entrée dans l'historique correspond aux valeurs présentes, à la date de dernière modification
+                {
+                    ...ref,
+                    date: this.formatDate(entries[0].date, "d B"),
+                    year: this.formatDate(entries[0].date, "y")
+                },
+
+                // puis on ajoute une entrée dans l'historique pour chaque entrée dans le changelog
+                ...entries.map(({ diff, index }) => {
+                    // on reconstitue l'état "old" à ajouter dans l'historique
+                    diff.forEach(({ fieldKey, oldValue }) => {
+                        ref[fieldKey] =
+                            oldValue === "non renseigné" ? "-" : oldValue;
+                    });
+
+                    // la date associée à cet état "old" est soit la date de l'entrée suivante dans le changelog s'il y en a une, soit la date de déclaration du site
+                    let date;
+                    if (index < entries.length - 1) {
+                        ({ date } = entries[index + 1]);
+                    } else {
+                        date = this.town.createdAt;
+                    }
+
+                    return {
+                        ...ref,
+                        date: this.formatDate(date, "d B"),
+                        year: this.formatDate(date, "y")
+                    };
+                })
+            ];
         },
         socialDiagnostic() {
             if (this.town.censusStatus === "done") {

--- a/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
+++ b/src/js/app/pages/TownDetails/TownDetailsPanelPeople.vue
@@ -223,8 +223,10 @@ export default {
 
             let ref = { ...present };
             const past = this.town.changelog.reduce((acc, log, index) => {
-                const diff = log.diff.filter(({ fieldKey }) =>
-                    fieldKey.startsWith("population")
+                const diff = log.diff.filter(
+                    ({ fieldKey }) =>
+                        fieldKey.startsWith("population") ||
+                        fieldKey === "minorsInSchool"
                 );
                 if (diff.length === 0) {
                     return acc;


### PR DESCRIPTION
Deux bugs corrigés concernant l'historique des habitants :
- avant, on associait à tort l'état "courant" du nombre d'habitants à la dernière date de modification du site : en réalité, ça doit être à la dernière date de modification d'un des champs de la section "Habitants"
- l'introduction du champ "minorsInSchool" a posé problème parce que l'algorithme de calcul de l'historique s'appuyait sur le fait que les champs de population étaient préfixés par "population" : il a fallu rajouter cette exception

J'ai complètement revu l'algorithme de calcul de l'historique selon le méta-aglo suivant :
```
$ENTREES$ = Toutes les entrées dans l'historique qui contiennent au moins un changement de population
$VALEURS$ = valeurs présentes

Si $ENTREES$ est vide Alors
    Un seul élément dans l'historique : $VALEURS$ + town.createdAt
Sinon
    Ajouter un premier élément dans l'historique : $VALEURS$ + date de la première entrée dans $ENTREES$
    Pour chaque entrée dans $ENTREES$ Faire
        $VALEURS$ = $VALEURS$ modifiée selon le diff de l'entrée pour reconstruire la version old

        Si c'est la dernière entrée Alors
            $DATE$ = town.createdAt
        Sinon
            $DATE$ = date de l'entrée suivante
        Fin si

        Ajouter un élément dans l'historique : $VALEURS$ + $DATE$
    Fin pour chaque
Fin si
```

Voir les tickets :
- https://trello.com/c/1j0p9yw8/833
- https://trello.com/c/QXJE9uw2/852