### PR TITLE
Correction de l'url de l'export 

### DIFF
--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -163,7 +163,7 @@ export default {
         download() {
             const { code, type } = this.location.data;
             let url = `${
-                process.env.VUE_APP_API_URL
+                window.RB_ENV.VUE_APP_API_URL
             }/towns/export?locationType=${encodeURIComponent(
                 type
             )}&locationCode=${encodeURIComponent(code)}&closedTowns=${


### PR DESCRIPTION
Correction de l'url de l'export, probablement causé par https://github.com/MTES-MCT/action-bidonvilles/pull/92