### PR TITLE
Ajout d'une action pour les releases manuelles 

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -1,0 +1,34 @@
+name: manual_release
+
+on:
+    workflow_dispatch:
+        inputs:
+            branch:
+                default: 'master'
+                description: 'Branch to checkout (master, issue/x)'
+            tag:
+                description: 'Docker tag'
+                default: 'dev'
+
+jobs:
+    build-docker-image:
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.event.inputs.branch }}
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+            - name: Login to DockerHub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Build and push
+              id: docker_build
+              uses: docker/build-push-action@v2
+              with:
+                  push: true
+                  tags: resorptionbidonvilles/frontend:latest,resorptionbidonvilles/frontend:${{ steps.tag.outputs.new_tag }}
+            - name: Image digest
+              run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

PR liée: https://github.com/MTES-MCT/action-bidonvilles-api/pull/70