### PR TITLE
fix(942) Fix de Sentry en production

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,12 +28,6 @@
                 "describe": "readonly",
                 "it": "readonly"
             }
-        },
-        {
-            "files": "src/**/*.js",
-            "globals": {
-                "RB_ENV": "readonly"
-            }
         }
     ]
 }

--- a/src/js/app/components/export/export.js
+++ b/src/js/app/components/export/export.js
@@ -1,5 +1,6 @@
 import { open } from "#helpers/api/main";
 import { getPermission } from "#helpers/api/config";
+import { VUE_APP_API_URL } from "#src/js/env.js";
 
 export default {
     props: {
@@ -127,9 +128,7 @@ export default {
         },
         download() {
             const { code, type } = this.location.data;
-            let url = `${
-                RB_ENV.VUE_APP_API_URL
-            }/towns/export?locationType=${encodeURIComponent(
+            let url = `${VUE_APP_API_URL}/towns/export?locationType=${encodeURIComponent(
                 type
             )}&locationCode=${encodeURIComponent(code)}&closedTowns=${
                 this.closedTowns ? "1" : "0"

--- a/src/js/app/components/export2/Export.vue
+++ b/src/js/app/components/export2/Export.vue
@@ -70,6 +70,7 @@
 import { open } from "#helpers/api/main";
 import { getPermission } from "#helpers/api/config";
 import Checkbox from "#app/components/ui/Form/input/Checkbox";
+import { VUE_APP_API_URL } from "#src/js/env.js";
 
 export default {
     components: { Checkbox },
@@ -162,9 +163,7 @@ export default {
     methods: {
         download() {
             const { code, type } = this.location.data;
-            let url = `${
-                window.RB_ENV.VUE_APP_API_URL
-            }/towns/export?locationType=${encodeURIComponent(
+            let url = `${VUE_APP_API_URL}/towns/export?locationType=${encodeURIComponent(
                 type
             )}&locationCode=${encodeURIComponent(code)}&closedTowns=${
                 this.closedTowns ? "1" : "0"

--- a/src/js/env.js
+++ b/src/js/env.js
@@ -1,4 +1,10 @@
-window.RB_ENV = {
+const version = require("./version.json");
+
+module.exports = {
     VUE_APP_API_URL: process.env.VUE_APP_API_URL || "${VUE_APP_API_URL}",
-    VUE_APP_MATOMO_ON: process.env.VUE_APP_MATOMO_ON || "${VUE_APP_MATOMO_ON}"
+    VUE_APP_MATOMO_ON: process.env.VUE_APP_MATOMO_ON || "${VUE_APP_MATOMO_ON}",
+    VUE_APP_SENTRY_ON: process.env.VUE_APP_SENTRY_ON || "${VUE_APP_SENTRY_ON}",
+    VUE_APP_SENTRY: process.env.VUE_APP_SENTRY || "${VUE_APP_SENTRY}",
+    VUE_APP_VERSION: version,
+    VUE_APP_SENTRY_RELEASE: `rb-front@${version}`
 };

--- a/src/js/helpers/api/main.js
+++ b/src/js/helpers/api/main.js
@@ -3,6 +3,7 @@ import { getToken, logout } from "#helpers/api/user";
 import { router } from "#app/router";
 import { open as openTab } from "#helpers/tabHelper";
 import version from "#root/version.json";
+import { VUE_APP_API_URL } from "#src/js/env.js";
 
 /**
  * Generic error codes
@@ -96,7 +97,7 @@ function handleRequestFailure(callback) {
 function request(method, url, data, headers = {}) {
     const xhr = new XMLHttpRequest();
     const promise = new Promise((success, failure) => {
-        xhr.open(method, `${RB_ENV.VUE_APP_API_URL}${url}`);
+        xhr.open(method, `${VUE_APP_API_URL}${url}`);
 
         Object.keys(headers).forEach(name => {
             xhr.setRequestHeader(name, headers[name]);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,3 @@
-import "./env.js";
-
 // load the whole betagouv template
 import "@openfonts/fira-code_all";
 import "simplebar/dist/simplebar.min.css";
@@ -8,14 +6,21 @@ import Vue from "vue";
 import * as Sentry from "@sentry/vue";
 import { Integrations } from "@sentry/tracing";
 
+import {
+    VUE_APP_SENTRY_ON,
+    VUE_APP_SENTRY,
+    VUE_APP_SENTRY_RELEASE,
+    VUE_APP_MATOMO_ON
+} from "#src/js/env.js";
+
 // Sentry should be loaded as soon as possible
-if (process.env.VUE_APP_SENTRY) {
+if (VUE_APP_SENTRY_ON === "true") {
     Sentry.init({
         Vue,
         // Sentry is only enabled for production env atm, we should differentiate envs if we use it for preprod/staging
         environment: "production",
-        release: process.env.VUE_APP_SENTRY_RELEASE,
-        dsn: process.env.VUE_APP_SENTRY,
+        release: VUE_APP_SENTRY_RELEASE,
+        dsn: VUE_APP_SENTRY,
         integrations: [new Integrations.BrowserTracing()],
 
         // Use this hook to scrub sensitive data sent to Sentry
@@ -171,7 +176,7 @@ Vue.component("font-awesome-icon", FontAwesomeIcon);
 Vue.use(VueRouter);
 Vue.use(VueI18n);
 
-if (RB_ENV.VUE_APP_MATOMO_ON === "true") {
+if (VUE_APP_MATOMO_ON === "true") {
     Vue.use(VueMatomo, {
         // Configure your matomo server and site by providing
         host: "https://stats.data.gouv.fr",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,9 +1,7 @@
 const path = require("path");
 const SentryPlugin = require("@sentry/webpack-plugin");
 
-const version = require("./src/js/version.json");
-process.env.VUE_APP_VERSION = version;
-process.env.VUE_APP_SENTRY_RELEASE = `rb-front@${version}`;
+const { VUE_APP_SENTRY_RELEASE } = require("./src/js/env.js");
 
 module.exports = {
     pages: {
@@ -18,17 +16,17 @@ module.exports = {
         plugins: [
             ...(process.env.VUE_APP_SENTRY_SOURCEMAP_AUTHKEY
                 ? [
-                    new SentryPlugin({
-                        authToken:
-                            process.env.VUE_APP_SENTRY_SOURCEMAP_AUTHKEY,
-                        release: process.env.VUE_APP_SENTRY_RELEASE,
-                        org: "resorption-bidonvilles",
-                        project: "resorption-bidonvilles",
+                      new SentryPlugin({
+                          authToken:
+                              process.env.VUE_APP_SENTRY_SOURCEMAP_AUTHKEY,
+                          release: VUE_APP_SENTRY_RELEASE,
+                          org: "resorption-bidonvilles",
+                          project: "resorption-bidonvilles",
 
-                        // webpack specific configuration
-                        include: "./dist"
-                    })
-                ]
+                          // webpack specific configuration
+                          include: "./dist"
+                      })
+                  ]
                 : [])
         ]
     },
@@ -39,7 +37,7 @@ module.exports = {
             .set("#root", path.resolve(__dirname, "./src/js/"))
             .set("#src", path.resolve(__dirname, "./src/"))
             .set("#helpers", path.resolve(__dirname, "./src/js/helpers"));
-        config.plugins.delete('progress');
+        config.plugins.delete("progress");
     },
 
     lintOnSave: false


### PR DESCRIPTION
Le sourcemapping ne va pas encore marcher, mais c'est un pas en avant.

J'ai fait en sorte que les variables d'environnemment ne soient plus définies dans un objet `window.RB_ENV` mais simplement exportées.
En plus d'être plus clean, ça permet de récupérer ces variables d'environnement depuis vue.config.js qui plantait si on utilisait window (inexistant dans un contexte cli).