### PR TITLE
#patch Statistiques privés - Ajout de la date de référence pour les résorptions

### DIFF
--- a/src/js/app/pages/PrivateStats/KeyMetric.vue
+++ b/src/js/app/pages/PrivateStats/KeyMetric.vue
@@ -1,8 +1,9 @@
 <template>
-    <div class="p-4 flex items-center justify-center border-2 border-black">
+    <div class="py-4 flex  justify-center border-2 border-black">
         <div class="flex flex-col items-center">
             <div class="text-display-md">{{ value }}</div>
             <div>{{ label }}</div>
+            <div class="text-xs text-center">{{ info }}</div>
         </div>
     </div>
 </template>
@@ -11,6 +12,9 @@
 export default {
     props: {
         label: {
+            type: String
+        },
+        info: {
             type: String
         },
         value: {

--- a/src/js/app/pages/PrivateStats/index.vue
+++ b/src/js/app/pages/PrivateStats/index.vue
@@ -26,6 +26,7 @@
                             <KeyMetric
                                 :value="stats.numberOfResorbedShantytown || 0"
                                 label="résorptions"
+                                info="depuis janv. 2019"
                             />
                             <KeyMetric
                                 :value="stats.numberOfPlans || 0"


### PR DESCRIPTION
https://trello.com/c/7b4COJXe/948-retour-stat-priv%C3%A9es

![image](https://user-images.githubusercontent.com/5053593/117330080-9cdcac80-ae95-11eb-8422-31ab3c563ded.png)