### PR TITLE
#patch (906) Suppression d'une route inutile

### DIFF
--- a/src/js/helpers/api/town.js
+++ b/src/js/helpers/api/town.js
@@ -110,19 +110,6 @@ export function addCovidComment(id, data) {
 }
 
 /**
- * Edits a comment from a town
- *
- * @param {string}                 townId    Town id
- * @param {number}                 commentId Comment id
- * @param {ShantytownComment_Data} data      Comment data
- *
- * @returns {Promise}
- */
-export function editComment(townId, commentId, comment) {
-    return postApi(`/towns/${townId}/comments/${commentId}`, comment);
-}
-
-/**
  * Delete a comment from a town
  *
  * @param {string} townId    Town id


### PR DESCRIPTION
La route de mise à jour d'un commentaire n'est plus utilisée depuis la mise en place du nouveau design system.
Suppression de cette route.

PR côté API : https://github.com/MTES-MCT/action-bidonvilles-api/pull/85