### PR TITLE
 #patch (1013) Ajout d'un graphique avec l'évolution du nombre d'habitants

### DIFF
--- a/src/js/app/pages/PrivateStats/index.vue
+++ b/src/js/app/pages/PrivateStats/index.vue
@@ -86,6 +86,29 @@
                     </div>
 
                     <div>
+                        <h2 class="text-display-md text-primary mb-4 mt-16">
+                            Nombre d'habitants en bidonvilles
+                        </h2>
+
+                        <div v-if="stats">
+                            <LineChart
+                                :chartData="populationTotalEvolutionData"
+                                :options="{
+                                    maintainAspectRatio: false,
+                                    scales: {
+                                        yAxes: [
+                                            { ticks: { beginAtZero: false } }
+                                        ]
+                                    }
+                                }"
+                                :height="250"
+                            />
+                        </div>
+
+                        <Spinner v-else />
+                    </div>
+
+                    <div>
                         <h2 class="text-display-md text-primary  mt-16 mb-4">
                             Suivi des dispositifs
                         </h2>
@@ -329,6 +352,25 @@ export default {
                         backgroundColor: "#E5E5F4",
                         data: cumulativeData,
                         label: "Nombre total de bidonvilles"
+                    }
+                ]
+            };
+        },
+
+        populationTotalEvolutionData() {
+            if (this.stats.populationTotal === null) {
+                return [];
+            }
+
+            return {
+                labels: this.stats.populationTotal.map(({ month }) => month),
+                datasets: [
+                    {
+                        backgroundColor: "#E5E5F4",
+                        data: this.stats.populationTotal.map(
+                            ({ total }) => total
+                        ),
+                        label: "Nombre d'habitants"
                     }
                 ]
             };


### PR DESCRIPTION
À tester avec la branche api : issue/1013
Voir la PR côté API : https://github.com/MTES-MCT/action-bidonvilles-api/pull/91

*Graphique au national :*
![Capture d’écran 2021-05-19 à 17 42 55](https://user-images.githubusercontent.com/1801091/118846419-f8169200-b8cc-11eb-88b4-99e6a69ffe02.png)

*Les données du mois courant matchent bien le chiffre clé du nombre d'habitants :*
![Capture d’écran 2021-05-19 à 17 42 58](https://user-images.githubusercontent.com/1801091/118846502-0e245280-b8cd-11eb-92c7-00578af5eada.png)

*Exemple pour un département :*
![Capture d’écran 2021-05-19 à 17 43 11](https://user-images.githubusercontent.com/1801091/118846529-167c8d80-b8cd-11eb-8889-9abdcc9c7cf3.png)