### PR TITLE
#patch (1028) Changer le wording "stats privées" par "Tableau de bord"

### DIFF
--- a/src/js/app/layouts/navbar/items.js
+++ b/src/js/app/layouts/navbar/items.js
@@ -77,7 +77,7 @@ export default {
                     group: "userCreation"
                 },
                 {
-                    label: "Statistiques",
+                    label: "Tableau de bord",
                     target: "/statistiques",
                     group: "stats"
                 },

--- a/src/js/app/pages/PrivateStats/LeftColumn.vue
+++ b/src/js/app/pages/PrivateStats/LeftColumn.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="leftContainer">
         <h1 class="text-display-md mb-4">
-            Statistiques
+            Tableau de bord
         </h1>
 
         <div>

--- a/src/js/app/router.js
+++ b/src/js/app/router.js
@@ -456,7 +456,7 @@ const router = new VueRouter({
         {
             path: "/statistiques/:code?",
             meta: {
-                group: "admin",
+                group: "stats",
                 permissions: ["stats.read"]
             },
             component: PrivateStats,


### PR DESCRIPTION
https://trello.com/c/TRCKKFkT/1028-changement-le-wording-stats-priv%C3%A9es-par-tableau-de-bord-dans-le-menu-et-le-titre-de-la-page

![image](https://user-images.githubusercontent.com/5053593/119473725-bb72ec80-bd4b-11eb-92b0-4dab0bcee863.png)
