### PR TITLE
#patch (953) Rétablir la suppression de ligne de financements

### DIFF
--- a/src/js/app/components/form/input/planFunding/planFundingRow/planFundingRow.pug
+++ b/src/js/app/components/form/input/planFunding/planFundingRow/planFundingRow.pug
@@ -17,6 +17,6 @@
         <span v-if="index === 0">À remplir entre janvier et mars de l'année prochaine</span>
     </td>
     <td>
-        <img src="/img/remove.svg" @click="remove" />
+        <img src="/img/remove.svg" style="max-width: none" @click="remove" />
     </td>
 </tr>


### PR DESCRIPTION
En fait la suppression de lignes de financement était déjà possible et il y a eu une régression à l'intégration de tailwind qui a fait que le bouton de suppression a disparu (`max-width: 100%` sur les `img` faisait que le bouton avait une width de 0).

Je suis allé au plus simple avec un style inline, c'est un composant v1 de toute façon.