### PR TITLE
#patch (1087) Update couting method of WAU

### DIFF
--- a/packages/frontend/src/js/app/pages/PrivateStats/index.vue
+++ b/packages/frontend/src/js/app/pages/PrivateStats/index.vue
@@ -200,11 +200,9 @@ export default {
             };
 
             const fetchStatsData = async date => {
-                const segment = `segment=pageUrl%3D@https%25253A%25252F%25252Fresorption-bidonvilles.beta.gouv.fr%25252F%252523%25252Fcartographie${
-                    this.$route.params.code
-                        ? `;customVariableName5==departement_code;customVariableValue5==${this.$route.params.code}`
-                        : ""
-                }`;
+                const segment = `segment=customVariableValue1==false,customVariableValue1=@${encodeURIComponent(
+                    "superuser:false"
+                )}`;
 
                 const url = `https://stats.data.gouv.fr/index.php?module=API&method=VisitsSummary.getUniqueVisitors&idSite=86&period=week&date=${date}&format=JSON&${segment}`;
 


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/sZuNkGCS/1087

## 🛠 Description de la PR
On utilise désormais la règle suivante : `valeur de var1 = false OU valeur de var1 contient superuser:false`.
Cette règle permet :
- de compter uniquement les utilisateurs connectés puisque var1 n'a une valeur que pour les utilisateurs connectés
- d'exclure l'équipe de la plateforme du décompte puisque var1 = true pour nous, et false pour les utilisateurs "normaux"
- de rester rétroactif en supportant l'ancien ET le nouveau format du tracking matomo

## 📸 Captures d'écran
- la courbe avant :
![Capture d’écran 2021-06-24 à 12 07 53](https://user-images.githubusercontent.com/1801091/123245917-8e9a2c80-d4e5-11eb-8045-433de3b1817e.png)

- la courbe après :
![image](https://user-images.githubusercontent.com/1801091/123245943-94900d80-d4e5-11eb-8cb2-3fd871603d0b.png)


## 🚨 Notes pour la mise en production
Ø