### PR TITLE
#patch (993) Rendre les commentaires Covid accessibles à tous

### DIFF
--- a/packages/api/server/models/shantytownModel.js
+++ b/packages/api/server/models/shantytownModel.js
@@ -905,9 +905,10 @@ module.exports = (database) => {
                         shantytown_comments(
                             description,
                             fk_shantytown,
-                            created_by
+                            created_by,
+                            private
                         )
-                    VALUES (:description, :shantytownId, :createdBy)
+                    VALUES (:description, :shantytownId, :createdBy, false)
                     RETURNING shantytown_comment_id AS id`,
             {
                 replacements: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/UdOhVRUA/993

## 🛠 Description de la PR
La colonne `private` de `shantytown_comments` était toujours set à `true` pour les commentaires COVID.

## 🚨 Notes pour la mise en production
Ø