### PR TITLE
#patch (1143) La fiche d'un site ne se met pas à jour en cas de fermeture ou nouveau commentaire COVID

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetails.vue
@@ -126,14 +126,12 @@
             :town="town"
             :isOpen="covidOpen"
             :closePanel="() => (covidOpen = false)"
-            v-on:updateTown="town = $event"
         />
         <!--  Close Shantytown Modal -->
         <TownDetailsCloseModal
             :town="town"
             :isOpen="closeOpen"
             v-on:closeModal="closeOpen = false"
-            v-on:updateTown="town = $event"
         />
         <!--  Self themes modal -->
         <TownDetailsActorThemesModal

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCloseModal.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCloseModal.vue
@@ -200,10 +200,11 @@ export default {
                 text: "Le site a bien été marqué comme fermé"
             });
 
-            const updatedTown = await get(this.$route.params.id);
-            this.$emit("updateTown", updatedTown);
             this.loading = false;
             this.closeModal();
+
+            const updatedTown = await get(this.$route.params.id);
+            await this.$store.dispatch("setDetailedTown", updatedTown);
         },
         closePopin() {
             this.$emit("cancelCloseTown");

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -32,7 +32,10 @@
                 </div>
 
                 <ValidationObserver ref="form" v-slot="{ handleSubmit }">
-                    <form @submit.prevent="handleSubmit(addCovidComment)">
+                    <form
+                        @submit.prevent="handleSubmit(addCovidComment)"
+                        ref="form"
+                    >
                         <DatepickerV2
                             class="w-64"
                             label="Date de votre intervention"
@@ -209,20 +212,24 @@ export default {
                     "besoin_action"
                 )
             })
-                .then(response => {
+                .then(async response => {
                     this.$piwik?.trackEvent(
                         "Commentaire",
                         "Création commentaire Covid",
                         this.town.id
                     );
 
-                    this.$emit("updateTown", {
-                        ...this.town,
-                        comments: {
-                            ...this.town.comments,
-                            covid: response
-                        }
-                    });
+                    try {
+                        await this.$store.dispatch("setDetailedTown", {
+                            ...this.town,
+                            comments: {
+                                ...this.town.comments,
+                                covid: response
+                            }
+                        });
+                    } catch (ignore) {
+                        //
+                    }
 
                     this.form = {
                         newComment: "",

--- a/packages/frontend/src/js/app/store/index.js
+++ b/packages/frontend/src/js/app/store/index.js
@@ -60,6 +60,13 @@ export default new Vuex.Store({
         },
         setDetailedTown(state, town) {
             state.detailedTown = town;
+
+            const index = state.towns.data.findIndex(
+                ({ id }) => id === town.id
+            );
+            if (index >= 0) {
+                state.towns.data[index] = town;
+            }
         },
         updateShantytownActors(state, { townId, actors }) {
             if (
@@ -189,6 +196,10 @@ export default new Vuex.Store({
 
         inviteNewTownActor(args, { townId, email }) {
             return inviteNewActor(townId, email);
+        },
+
+        setDetailedTown({ commit }, town) {
+            commit("setDetailedTown", town);
         }
     },
     getters: {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/qr9WiUq8/1143

## 🛠 Description de la PR
Depuis "J'interviens ici", le site sélectionné est stocké dans le store, ce qui a rendu caduc la mise à jour du site en cas de fermeture ou de nouveau commentaire COVID (on ne peut pas modifier le contenu du store sans passer par une action).

Cette PR corrige ce problème en ajoutant l'action manquante.

## 🚨 Notes pour la mise en production
Ø