### PR TITLE
#patch (1144) Un message d'erreur apparaît au reset du formulaire d'ajout de commentaire COVID

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCovidCommentsSidePanel.vue
@@ -229,6 +229,9 @@ export default {
                         date: new Date(),
                         interventionType: []
                     };
+                    this.$nextTick(() => {
+                        this.$refs.form.reset();
+                    });
                     this.loading = false;
                 })
                 .catch(response => {


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/MZyiLzSV/1144

## 🛠 Description de la PR
En vidant les champs du formulaire, un message d'erreur apparaît sur les champs obligatoires : il manquait un `reset()` sur le formulaire.

## 📸 Captures d'écran
- Le message qui apparaissait après ajout d'un commentaire
<img width="488" alt="Capture d’écran 2021-07-02 à 23 08 35" src="https://user-images.githubusercontent.com/1801091/124328710-703dcc00-db8a-11eb-9cde-8cba047deda8.png">

## 🚨 Notes pour la mise en production
Ø