### PR TITLE
#minor (1079) Définition "site résorbé" sur pop-up de fermeture et le tableau de bord

### DIFF
--- a/packages/frontend/src/js/app/pages/PrivateStats/index.vue
+++ b/packages/frontend/src/js/app/pages/PrivateStats/index.vue
@@ -11,48 +11,60 @@
                         {{ territory.name }}
                     </div>
                     <div>
-                        <div
-                            class="grid grid-cols-6 gap-8 mt-8 mb-16"
-                            v-if="stats"
-                        >
-                            <KeyMetric
-                                :value="stats.numberOfPeople || 0"
-                                label="habitants"
-                            />
-                            <KeyMetric
-                                :value="stats.numberOfShantytown || 0"
-                                label="sites"
-                            />
-                            <KeyMetric
-                                :value="stats.numberOfResorbedShantytown || 0"
-                                label="résorptions"
-                                info="depuis janv. 2019"
-                            />
-                            <KeyMetric
-                                :value="stats.numberOfPlans || 0"
-                                label="dispositifs"
-                            />
-                            <KeyMetric
-                                :value="stats.numberOfUsers || 0"
-                                label="utilisateurs"
-                            />
-                            <KeyMetric
-                                :value="
-                                    stats.averageCompletionPercentage
-                                        ? (
-                                              stats.averageCompletionPercentage *
-                                              100
-                                          ).toFixed(2) + '%'
-                                        : 0
-                                "
-                                label="completion"
-                            />
+                        <div v-if="stats" class="mt-8">
+                            <div class="grid grid-cols-6 gap-8 mb-4">
+                                <KeyMetric
+                                    :value="stats.numberOfPeople || 0"
+                                    label="habitants"
+                                />
+                                <KeyMetric
+                                    :value="stats.numberOfShantytown || 0"
+                                    label="sites"
+                                />
+                                <KeyMetric
+                                    :value="
+                                        stats.numberOfResorbedShantytown || 0
+                                    "
+                                    label="résorptions"
+                                    info="depuis janv. 2019"
+                                />
+                                <KeyMetric
+                                    :value="stats.numberOfPlans || 0"
+                                    label="dispositifs"
+                                />
+                                <KeyMetric
+                                    :value="stats.numberOfUsers || 0"
+                                    label="utilisateurs"
+                                />
+                                <KeyMetric
+                                    :value="
+                                        stats.averageCompletionPercentage
+                                            ? (
+                                                  stats.averageCompletionPercentage *
+                                                  100
+                                              ).toFixed(2) + '%'
+                                            : 0
+                                    "
+                                    label="completion"
+                                />
+                            </div>
+                            <div class="text-sm">
+                                <span class="font-bold">Site résorbé : </span
+                                >une solution pérenne en logement ou hébergement
+                                a été mise en place pour 66 % des habitants du
+                                site
+                            </div>
+                            <div class="text-sm">
+                                <span class="font-bold">Complétion : </span
+                                >pourcentage d'informations renseignées sur la
+                                fiche d'un site
+                            </div>
                         </div>
                         <Spinner v-else />
                     </div>
 
                     <div>
-                        <h2 class="text-display-md text-primary mb-4 mt-16">
+                        <h2 class="text-display-md text-primary mb-4 mt-8">
                             Suivi des sites
                         </h2>
                         <div v-if="stats">

--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCloseModal.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsCloseModal.vue
@@ -28,9 +28,7 @@
                             id="closed_with_solutions"
                             rules="required"
                             label="Est-ce que ce site a été résorbé définitivement ?"
-                            info="C’est-à-dire sans réinstallation illicite et
-                                avec un accompagnement de la majorité des
-                                personnes vers des solutions pérennes"
+                            info="Un site est considéré comme résorbé si une solution pérenne en logement ou hébergement est mise en place pour 66 % des habitants du site."
                             validationName="Est-ce que ce site a été résorbé définitivement ?"
                         >
                             <Radio


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/gf2PwKh5/1079-d%C3%A9finition-site-r%C3%A9sorb%C3%A9-sur-pop-up-de-fermeture-et-le-tableau-de-bord-d%C3%A9finition-du-taux-de-compl%C3%A9tion-sur-le-tableau-de-bord

## 🛠 Description de la PR
- Changement de wording sur la modal de fermeture
- Ajout de la définition sur les stats privés

## 📸 Captures d'écran

![image](https://user-images.githubusercontent.com/5053593/124448799-1ce29e00-dd83-11eb-88a0-f56b52d38f81.png)

![image](https://user-images.githubusercontent.com/5053593/124448772-13f1cc80-dd83-11eb-9dd0-387140ae9156.png)