### PR TITLE
#patch (1101) Ajout d'un loader à l'ajout d'un commentaire

### DIFF
--- a/packages/frontend/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
+++ b/packages/frontend/src/js/app/pages/TownDetails/TownDetailsNewComment.vue
@@ -45,7 +45,12 @@
                 <Button variant="primaryText" @click="cancelComment"
                     >Annuler</Button
                 >
-                <Button variant="tertiary" @click="addComment">Valider</Button>
+                <Button
+                    variant="tertiary"
+                    @click="addComment"
+                    :loading="loading"
+                    >Valider</Button
+                >
             </div>
         </div>
     </div>
@@ -61,7 +66,8 @@ export default {
             commentError: null,
             commentErrors: {},
             newComment: "",
-            isPrivate: false
+            isPrivate: false,
+            loading: false
         };
     },
     props: {
@@ -77,23 +83,24 @@ export default {
         cancelComment() {
             this.newComment = "";
         },
-        addComment() {
+        async addComment() {
             // clean previous errors
             this.commentError = null;
             this.commentErrors = {};
+            this.loading = true;
 
-            apiAddComment(this.$route.params.id, {
-                description: this.newComment,
-                private: this.isPrivate
-            })
-                .then(response => {
-                    this.$emit("submit", response.comments);
-                    this.newComment = "";
-                })
-                .catch(response => {
-                    this.commentError = response.user_message;
-                    this.commentErrors = response.fields || {};
+            try {
+                const response = await apiAddComment(this.$route.params.id, {
+                    description: this.newComment,
+                    private: this.isPrivate
                 });
+                this.$emit("submit", response.comments);
+                this.newComment = "";
+            } catch (response) {
+                this.commentError = response.user_message;
+                this.commentErrors = response.fields || {};
+            }
+            this.loading = false;
         }
     }
 };


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/oidq4rRt/1101-bouton-validation-de-commentaire-quand-on-clique-sur-le-bouton-denvoi-du-commentaire-il-ne-se-d%C3%A9sactive-pas-le-temps-que-lenvoi

## 🛠 Description de la PR
Ajout d'un loader sur le bouton de création de commentaire 